### PR TITLE
Added util to check if a work is restricted

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,10 @@ import {
  getProfileLocation,
  getProfileBday
 } from "./utils/user";
+import { 
+ Restricted,
+ checkLock, 
+ getLockedCheck} from "./utils/restrict";
 
 import axios from "axios";
 import { setupCache } from "axios-cache-adapter";
@@ -71,3 +75,15 @@ export const getUser = async ({
    bioHtml: getProfileBio(profilePage),
  };
 };
+
+export const checkLocks = async ({
+ workID,
+}: {
+ workID: string;
+}): Promise<Restricted> => {
+ const theLocks = await getLockedCheck(workID)
+
+ return {
+  locked: checkLock(theLocks)
+ }
+}

--- a/src/tests/restrict.test.ts
+++ b/src/tests/restrict.test.ts
@@ -1,0 +1,14 @@
+import { checkLocks } from "..";
+import { getCheckingURL, getLockedCheck } from "../utils/restrict";
+
+describe("Checks status of a restricted work. NOTE: This test may fail if the owner of the example work changes it to unrestricted!", () => {
+ test("Checks a known restricted work.", async () => {
+  const work = await checkLocks( { workID: "15461226" } )
+
+  expect(work).toMatchObject({
+   locked: true
+  })
+
+ });
+
+})

--- a/src/tests/restrict.test.ts
+++ b/src/tests/restrict.test.ts
@@ -1,6 +1,8 @@
+//NOTE: This test may fail if the owner of the example work changes it to unrestricted!
+
 import { checkLocks } from "..";
 
-describe("Checks status of a restricted work. NOTE: This test may fail if the owner of the example work changes it to unrestricted!", () => {
+describe("Checks status of a restricted work.", () => {
  test("Checks a known restricted work.", async () => {
   const work = await checkLocks( { workID: "15461226" } )
 

--- a/src/tests/restrict.test.ts
+++ b/src/tests/restrict.test.ts
@@ -1,14 +1,21 @@
 import { checkLocks } from "..";
-import { getCheckingURL, getLockedCheck } from "../utils/restrict";
 
 describe("Checks status of a restricted work. NOTE: This test may fail if the owner of the example work changes it to unrestricted!", () => {
  test("Checks a known restricted work.", async () => {
   const work = await checkLocks( { workID: "15461226" } )
 
   expect(work).toMatchObject({
-   locked: true
+   locked: true,
   })
 
  });
+
+ test("Checks a known unrestricted work.", async () => {
+  const work = await checkLocks( { workID: "923647" })
+
+  expect(work).toMatchObject({
+   locked: false,
+  })
+ })
 
 })

--- a/src/utils/restrict.ts
+++ b/src/utils/restrict.ts
@@ -1,0 +1,27 @@
+import cheerio, { CheerioAPI } from "cheerio";
+
+import axios from "axios";
+
+interface CheckRestricted extends CheerioAPI {
+  kind: "CheckRestricted";
+}
+
+export interface Restricted {
+ locked: boolean;
+}
+
+export const getCheckingURL = (workID: string) => 
+ `https://archiveofourown.org/works/${workID}`;
+
+export const getLockedCheck = async (workID: string) => {
+ return cheerio.load(
+   (await axios.get<string>(getCheckingURL(workID))).data
+ ) as CheckRestricted;
+};
+
+export const checkLock = ($checkRestricted: CheckRestricted) => {
+ const checking = $checkRestricted("#signin > .heading)").text();
+ if (checking) {
+  return true;
+ } else { return false; }
+}

--- a/src/utils/restrict.ts
+++ b/src/utils/restrict.ts
@@ -20,7 +20,7 @@ export const getLockedCheck = async (workID: string) => {
 };
 
 export const checkLock = ($checkRestricted: CheckRestricted) => {
- const checking = $checkRestricted("#signin > .heading)").text();
+ const checking = $checkRestricted("#signin > .heading").text();
  if (checking) {
   return true;
  } else { return false; }


### PR DESCRIPTION
I don't know if having this on its own will be inefficient in the long term, but currently `restrict.ts` successfully checks for restricted/unrestricted status as tested by `restrict.test.ts`.

cc #9 Ria I hope I'm not unintentionally duplicating your work at this time 