### PR TITLE
corrects bug in word count and standardizes function name.

### DIFF
--- a/src/works/getters.ts
+++ b/src/works/getters.ts
@@ -31,8 +31,8 @@ export const getWorkTitle = ($workPage: WorkPage): string => {
   return $workPage("h2.title").text().trim();
 };
 
-export const getWorkWordcount = ($workPage: WorkPage): number => {
-  return parseInt($workPage("dd.words").text().trim());
+export const getWorkWordCount = ($workPage: WorkPage): number => {
+  return parseInt($workPage("dd.words").text().replaceAll(",", "").trim());
 };
 
 export const getWorkLanguage = ($workPage: WorkPage): string => {

--- a/src/works/index.ts
+++ b/src/works/index.ts
@@ -20,7 +20,7 @@ import {
   getWorkTotalChapters,
   getWorkUpdateDate,
   getWorkWarnings,
-  getWorkWordcount,
+  getWorkWordCount,
 } from "./getters";
 
 import { loadWorkPage } from "../page-loaders";
@@ -44,7 +44,7 @@ export const getWork = async ({
     id: workId,
     authors: getWorkAuthors(workPage),
     title: getWorkTitle(workPage),
-    words: getWorkWordcount(workPage),
+    words: getWorkWordCount(workPage),
     language: getWorkLanguage(workPage),
     rating: getWorkRating(workPage),
     category: getWorkCategory(workPage),


### PR DESCRIPTION
`getWordCount` was previously `getWordcount`. This corrects the camelCase of the function.

It also corrects a bug caused by using parseInt before removing commas in word counts obtained from AO3.