### PR TITLE
Add series and collection types

### DIFF
--- a/types/entities.ts
+++ b/types/entities.ts
@@ -140,7 +140,7 @@ export interface WorkSeries {
 }
 
 export interface WorkCollection {
-  name: string;
+  title: string;
   id: string;
   url: string;
 }

--- a/types/entities.ts
+++ b/types/entities.ts
@@ -126,3 +126,21 @@ export interface Chapter {
   publishedAt: string;
   url: string;
 }
+
+export interface WorkSeries {
+  id: string;
+  title: string;
+  url: string;
+  currentWork: {
+    id: string;
+    index: number;
+    prevWorkId: string | null;
+    nextWorkId: string | null;
+  };
+}
+
+export interface WorkCollection {
+  name: string;
+  id: string;
+  url: string;
+}


### PR DESCRIPTION
Finally making this PR based on previous discussions. I made a couple of judgement calls but feel free to comment on those or anything else you disagree with.
- removed the `url` property ms boba had added to `currentWork` because it seems redundant when you can create the URL when you need it from the current work `id`.
- called the property for a collection's name the `id`, to keep it consistent to the way we reffer to other unique identifiers that show up on AO3, specially ones related to URLs

## todo

- [ ] add methods to scrape series and collections
- [ ] add series and collections properties to work summary type
- [ ] add tests for these new methods